### PR TITLE
Feature/mm parser flexibility

### DIFF
--- a/server/src/__test__/MmParser.test.ts
+++ b/server/src/__test__/MmParser.test.ts
@@ -368,3 +368,27 @@ test('Test file inclusion', () => {
     expect(parser.diagnostics[0].code).toBe(MmParserWarningCode.unprovenStatement);
     expect(parser.diagnostics[0].mmFilePath).toContain(path.normalize('server/src/__test__/../mmTestFiles/included2.mm'));
 });
+
+test('buildLabelToStatementMap emits newLabel event when it finds a label', () => {
+    const mmParser = new MmParser();
+
+    mmParser.emit = jest.fn();
+
+    const mockTokenReader = {
+        indexForNextToken: 0,
+        tokens: {length: 1},
+        Readc: jest.fn().mockImplementation(() => {
+            if (mockTokenReader.indexForNextToken === 0) {
+                mockTokenReader.indexForNextToken = 6;
+                return {value: 'myLabel'};
+            } else {
+                return undefined;
+            }
+        }) as () => MmToken
+    } as TokenReader;
+
+    mmParser.buildLabelToStatementMap(mockTokenReader);
+
+    expect(mmParser.emit).toBeCalledTimes(1);
+    expect(mmParser.emit).toBeCalledWith('newLabel', {value: 'myLabel'});
+});

--- a/server/src/__test__/MmParser.test.ts
+++ b/server/src/__test__/MmParser.test.ts
@@ -10,6 +10,7 @@ import { TokensCreator } from '../mm/TokensCreator';
 import { MmToken } from '../grammar/MmLexer';
 import { TokenReader } from '../mm/TokenReader';
 import * as path from 'path';
+import { BlockStatement } from '../mm/BlockStatement';
 
 test("Parsing two $f statements", () => {
     const parser: MmParser = new MmParser();
@@ -370,7 +371,13 @@ test('Test file inclusion', () => {
 });
 
 test('buildLabelToStatementMap emits newLabel event when it finds a label', () => {
-    const mmParser = new MmParser();
+    class TestParser extends MmParser {
+        buildLabelToStatementMap(toks: TokenReader, currentBlock?: BlockStatement): void {
+            super.buildLabelToStatementMap(toks, currentBlock);
+        }
+    }
+
+    const mmParser = new TestParser();
 
     mmParser.emit = jest.fn();
 

--- a/server/src/__test__/ParseNodesCreatorThread.test.ts
+++ b/server/src/__test__/ParseNodesCreatorThread.test.ts
@@ -4,7 +4,17 @@ import { LabeledStatement } from '../mm/LabeledStatement';
 import { MmParser } from '../mm/MmParser';
 import { GrammarManagerForThread, IMmpRuleForThread } from '../parseNodesCreatorThread/GrammarManagerForThread';
 import { ParseNodeForThread } from '../parseNodesCreatorThread/ParseNodeForThread';
-import { addParseNodes, createParseNodesInANewThread, createLabelToFormulaMap, createLabelToParseNodeForThreadMap, defaultProgressCallback } from '../parseNodesCreatorThread/ParseNodesCreator';
+
+import {
+	addParseNodes,
+	createParseNodesInANewThread,
+	createLabelToFormulaMap,
+	createLabelToParseNodeForThreadMap,
+	defaultProgressCallback,
+	postMessage,
+	createMessageLog
+} from '../parseNodesCreatorThread/ParseNodesCreator';
+
 import { eqeq1iMmParser } from './GlobalForTest.test';
 import * as worker_threads from 'worker_threads';
 
@@ -32,8 +42,8 @@ describe("ParseNodesCreator.ts", () => {
 	});
 
 	test("Simulate working thread serialization, deserialization", () => {
-		const postMessage = jest.fn();
-		(worker_threads.parentPort as unknown) = {postMessage};
+		const postMessageMock = jest.fn();
+		(worker_threads.parentPort as unknown) = {postMessage: postMessageMock};
 
 		const mmParser: MmParser = eqeq1iMmParser;
 
@@ -53,7 +63,7 @@ describe("ParseNodesCreator.ts", () => {
 		const areEqual: boolean = GrammarManager.areParseNodesEqual(parseNode, parseNodeSimulated);
 		expect(areEqual).toBeTruthy();
 
-		const messages = postMessage.mock.calls.map(call => call[0]);
+		const messages = postMessageMock.mock.calls.map(call => call[0]);
 		const logMessages = messages.filter(message => message.kind === 'log');
 		const progressMessages = messages.filter(message => message.kind === 'progress');
 		const doneMessages = messages.filter(message => message.kind === 'done');
@@ -99,4 +109,22 @@ describe("ParseNodesCreator.ts", () => {
 			await expect(promise).resolves.toBeUndefined();
 		});
 	});
+
+
+	describe("postMessage", () => {
+
+		it("posts a log message", () => {
+			const postMessageMock = jest.fn();
+			(worker_threads.parentPort as unknown) = {postMessage: postMessageMock};
+			postMessage(createMessageLog('a log message'));
+			expect(postMessageMock).toHaveBeenCalledWith({kind: 'log', text: 'a log message'});
+		});
+
+		it(`doesn't fail if there is no parentPort`, () => {
+			expect(worker_threads.parentPort).toBeNull();
+			postMessage(createMessageLog('a log message'));
+		});
+
+
+	});	
 });

--- a/server/src/__test__/ParseNodesCreatorThread.test.ts
+++ b/server/src/__test__/ParseNodesCreatorThread.test.ts
@@ -4,7 +4,7 @@ import { LabeledStatement } from '../mm/LabeledStatement';
 import { MmParser } from '../mm/MmParser';
 import { GrammarManagerForThread, IMmpRuleForThread } from '../parseNodesCreatorThread/GrammarManagerForThread';
 import { ParseNodeForThread } from '../parseNodesCreatorThread/ParseNodeForThread';
-import { addParseNodes, createParseNodesInANewThread, createLabelToFormulaMap, createLabelToParseNodeForThreadMap, defaultProgressCallback, postDone, postLog, postProgress } from '../parseNodesCreatorThread/ParseNodesCreator';
+import { addParseNodes, createParseNodesInANewThread, createLabelToFormulaMap, createLabelToParseNodeForThreadMap, defaultProgressCallback } from '../parseNodesCreatorThread/ParseNodesCreator';
 import { eqeq1iMmParser } from './GlobalForTest.test';
 import * as worker_threads from 'worker_threads';
 
@@ -13,7 +13,11 @@ function buildParseNodesSimulated(mmParser: MmParser) {
 	const labelToFormulaMap: Map<string, string> = createLabelToFormulaMap(mmParser);
 	const mmpRulesForThread: IMmpRuleForThread[] =
 		GrammarManagerForThread.convertMmpRules(<MmpRule[]>mmParser.grammar.rules);
-	const labelToParseNodeForThreadMap: Map<string, ParseNodeForThread> = createLabelToParseNodeForThreadMap(labelToFormulaMap, mmpRulesForThread);
+	const labelToParseNodeForThreadMap: Map<string, ParseNodeForThread> = createLabelToParseNodeForThreadMap(
+		labelToFormulaMap,
+		mmpRulesForThread,
+	);
+
 	addParseNodes(labelToParseNodeForThreadMap, mmParser.labelToStatementMap);
 }
 
@@ -67,50 +71,6 @@ describe("ParseNodesCreator.ts", () => {
 
 		expect(progressMessages.length).toEqual(391);
 		expect(doneMessages).toEqual([]);
-	});
-
-	describe("postProgress", () => {
-		it("posts a progress message", () => {
-			const postMessage = jest.fn();
-			(worker_threads.parentPort as unknown) = {postMessage};
-			postProgress(7, 9);
-			expect(postMessage).toHaveBeenCalledWith({kind: 'progress', index: 7, count: 9});
-		});
-
-		it(`doesn't fail if there is no parentPort`, () => {
-			expect(worker_threads.parentPort).toBeNull();
-			postProgress(7, 9);
-		});
-	});
-
-	describe("postLog", () => {
-		it("posts a log message", () => {
-			const postMessage = jest.fn();
-			(worker_threads.parentPort as unknown) = {postMessage};
-			postLog('a log message');
-			expect(postMessage).toHaveBeenCalledWith({kind: 'log', text: 'a log message'});
-		});
-
-		it(`doesn't fail if there is no parentPort`, () => {
-			expect(worker_threads.parentPort).toBeNull();
-			postLog('a log message');
-		});
-	});
-
-	describe("postDone", () => {
-		const labelToParseNodeForThreadMap = new Map<string, ParseNodeForThread>();
-
-		it("posts a done message", () => {
-			const postMessage = jest.fn();
-			(worker_threads.parentPort as unknown) = {postMessage};
-			postDone(labelToParseNodeForThreadMap);
-			expect(postMessage).toHaveBeenCalledWith({kind: 'done', labelToParseNodeForThreadMap});
-		});
-
-		it(`doesn't fail if there is no parentPort`, () => {
-			expect(worker_threads.parentPort).toBeNull();
-			postDone(labelToParseNodeForThreadMap);
-		});
 	});
 
 	describe("createParseNodesInANewThread", () => {

--- a/server/src/mm/MmParser.ts
+++ b/server/src/mm/MmParser.ts
@@ -327,7 +327,9 @@ export class MmParser extends EventEmitter {
             }
         }
     }
-    private buildLabelToStatementMap(toks: TokenReader, currentBlock?: BlockStatement) {
+
+    // public for testing, only
+    public buildLabelToStatementMap(toks: TokenReader, currentBlock?: BlockStatement) {
         //TODO prova a valutare di evitare d'usare BlockStack
         //const currentBlock = new BlockStatement(this.outermostBlock.last())
         //this.outermostBlock.push(currentBlock)

--- a/server/src/mm/MmParser.ts
+++ b/server/src/mm/MmParser.ts
@@ -328,8 +328,7 @@ export class MmParser extends EventEmitter {
         }
     }
 
-    // public for testing, only
-    public buildLabelToStatementMap(toks: TokenReader, currentBlock?: BlockStatement) {
+    protected buildLabelToStatementMap(toks: TokenReader, currentBlock?: BlockStatement) {
         //TODO prova a valutare di evitare d'usare BlockStack
         //const currentBlock = new BlockStatement(this.outermostBlock.last())
         //this.outermostBlock.push(currentBlock)

--- a/server/src/mm/MmParser.ts
+++ b/server/src/mm/MmParser.ts
@@ -17,7 +17,7 @@ import { GlobalState } from '../general/GlobalState';
 import { EHyp } from './EHyp';
 import { FHyp } from './FHyp';
 import * as events from 'events';
-import { createParseNodesInANewThread, defaultProgressCallback, ProgressCallback } from '../parseNodesCreatorThread/ParseNodesCreator';
+import { createParseNodesInANewThread, createParseNodesInCurrentThread, defaultProgressCallback, ProgressCallback } from '../parseNodesCreatorThread/ParseNodesCreator';
 import { EventEmitter } from 'stream';
 import { IExtensionSettings } from './ConfigurationManager';
 import { TokenReader } from './TokenReader';
@@ -514,8 +514,10 @@ export class MmParser extends EventEmitter {
 
     //#region createParseNodesForAssertions
 
-    public async createParseNodesForAssertionsAsync(progressCallback: ProgressCallback = defaultProgressCallback) {
-        // if (this.isParsingComplete && !this.parseFailed)
+    public async createParseNodesForAssertionsAsync(
+        progressCallback: ProgressCallback = defaultProgressCallback
+    ): Promise<void> {
+
         if (this.isParsingComplete)
             await createParseNodesInANewThread(this, progressCallback);
     }
@@ -527,16 +529,13 @@ export class MmParser extends EventEmitter {
         return result;
     }
 
-    /** use this method only for testing small .mm files */
-    public createParseNodesForAssertionsSync() {
-        this.labelToStatementMap.forEach((labeledStatement: LabeledStatement) => {
-            // if (labeledStatement instanceof EHyp ||
-            //     labeledStatement instanceof AssertionStatement && !GrammarManager.isSyntaxAxiom2(labeledStatement)) {
-            if (MmParser.isParsable(labeledStatement)) {
-                // if the parseNode is undefined, it will create it
-                labeledStatement.parseNode;
-            }
-        });
-        this.areAllParseNodesComplete = true;
+    /** createParseNodesForAssertionsSync will lock up an interactive system while it runs, which
+     *  could be minutes for a large .mm file.  createParseNodesForAssertionsAsync is usually prefered. */
+    public createParseNodesForAssertionsSync(
+        progressCallback: ProgressCallback = defaultProgressCallback
+    ): void {
+        
+        if (this.isParsingComplete)
+            createParseNodesInCurrentThread(this, progressCallback);
     }
 }

--- a/server/src/mm/MmParser.ts
+++ b/server/src/mm/MmParser.ts
@@ -45,7 +45,8 @@ export enum MmParserWarningCode {
 export enum MmParserEvents {
     newAxiomStatement = "newAxiomStatement",
     newProvableStatement = "newProvableStatement",
-    parsingProgress = 'newParsingProgress' 
+    parsingProgress = 'newParsingProgress', 
+    newLabel = 'newLabel',
 }
 
 export type AssertionParsedArgs = {
@@ -387,10 +388,12 @@ export class MmParser extends EventEmitter {
                     break;
                 }
                 default:
-                    if (tok.value.substring(0, 0) !== "$")
+                    if (tok.value.substring(0, 0) !== "$") {
                         label = tok;
-                    else
+                        this.emit(MmParserEvents.newLabel, tok);
+                    } else {
                         this.fail('"Unexpexcted token: " + tok');
+                    }
                     break;
             }
             tok = toks.Readc();
@@ -462,7 +465,7 @@ export class MmParser extends EventEmitter {
     //     this.isParsingComplete = true;
     // }
 
-    private parseFromTokenReader(tokenReader: TokenReader) {
+    parseFromTokenReader(tokenReader: TokenReader) {
 
         this.isParsingComplete = false;
         this.outermostBlock.mmParser = this;

--- a/server/src/parseNodesCreatorThread/ParseNodesCreator.ts
+++ b/server/src/parseNodesCreatorThread/ParseNodesCreator.ts
@@ -30,19 +30,16 @@ type Message = MessageDone | MessageProgress | MessageLog;
 
 export type ProgressCallback = (message: MessageProgress | MessageLog) => void;
 
-export const postProgress = (index: number, count: number) => {
-	const message: MessageProgress = {kind: 'progress', index, count};
-	parentPort?.postMessage(message);
+export const createMessageProgress = (index: number, count: number): MessageProgress => {
+	return {kind: 'progress', index, count};
 };
 
-export const postLog = (text: string) => {
-	const message: MessageLog = {kind: 'log', text};
-	parentPort?.postMessage(message);
+export const createMessageLog = (text: string): MessageLog => {
+	return {kind: 'log', text};
 };
 
-export const postDone = (labelToParseNodeForThreadMap: Map<string, ParseNodeForThread>) => {
-	const message: MessageDone = {kind: 'done', labelToParseNodeForThreadMap};
-	parentPort?.postMessage(message);
+export const createMessageDone = (labelToParseNodeForThreadMap: Map<string, ParseNodeForThread>): MessageDone => {
+	return {kind: 'done', labelToParseNodeForThreadMap};
 };
 
 export const defaultProgressCallback: ProgressCallback = (message) => {
@@ -60,11 +57,11 @@ export const defaultProgressCallback: ProgressCallback = (message) => {
 if (!isMainThread) {
 	const { labelToFormulaMap, mmpRulesForThread }: { labelToFormulaMap: Map<string, string>, mmpRulesForThread: IMmpRuleForThread[] } = workerData;
 
-	postLog('I am the worker thread!!!!!!!!!');
-	postLog('Worker thread!!!!: labelToFormulaMap.size = ' + labelToFormulaMap.size);
+	parentPort?.postMessage(createMessageLog('I am the worker thread!!!!!!!!!'));
+	parentPort?.postMessage('Worker thread!!!!: labelToFormulaMap.size = ' + labelToFormulaMap.size);
 	const labelToParseNodeForThreadMap: Map<string, ParseNodeForThread> =
 		createLabelToParseNodeForThreadMap(labelToFormulaMap, mmpRulesForThread);
-	postDone(labelToParseNodeForThreadMap);
+	parentPort?.postMessage(createMessageDone(labelToParseNodeForThreadMap));
 }
 
 //#region createLabelToParseNodeForThreadMap
@@ -99,15 +96,17 @@ function getParseNodeForThread(formula: string, grammar: Grammar, workingVars: W
 }
 
 // export for testing, only
-export function createLabelToParseNodeForThreadMap(labelToFormulaMap: Map<string, string>,
-	mmpRulesForThread: IMmpRuleForThread[]): Map<string, ParseNodeForThread> {
+export function createLabelToParseNodeForThreadMap(
+	labelToFormulaMap: Map<string, string>,
+	mmpRulesForThread: IMmpRuleForThread[]
+): Map<string, ParseNodeForThread> {
 	const labelToParseNodeForThreadMap: Map<string, ParseNodeForThread> = new Map<string, ParseNodeForThread>();
 	const workingVars: WorkingVars = new WorkingVars(new Map<string, string>());
 	const grammar: Grammar = createGrammar(mmpRulesForThread, workingVars);
 	const formulaToParseNodeForThreadCache: Map<string, ParseNodeForThread> = new Map<string, ParseNodeForThread>();
 	let i = 0;
 	labelToFormulaMap.forEach((formula: string, label: string) => {
-		postProgress(i++, labelToFormulaMap.size);
+		parentPort?.postMessage(createMessageProgress(i++, labelToFormulaMap.size));
 		// comment out the following line to avoid caching
 		const parseNodeForThread: ParseNodeForThread | undefined = getParseNodeForThread(
 			formula, grammar, workingVars, formulaToParseNodeForThreadCache);
@@ -117,8 +116,8 @@ export function createLabelToParseNodeForThreadMap(labelToFormulaMap: Map<string
 		if (parseNodeForThread != undefined)
 			labelToParseNodeForThreadMap.set(label, parseNodeForThread);
 	});
-	postLog('labelToParseNodeForThreadMap.size = ' + labelToParseNodeForThreadMap.size);
-	postLog('formulaToParseNodeForThreadCache.size = ' + formulaToParseNodeForThreadCache.size);
+	parentPort?.postMessage(createMessageLog('labelToParseNodeForThreadMap.size = ' + labelToParseNodeForThreadMap.size));
+	parentPort?.postMessage(createMessageLog('formulaToParseNodeForThreadCache.size = ' + formulaToParseNodeForThreadCache.size));
 	return labelToParseNodeForThreadMap;
 }
 //#endregion createLabelToParseNodeForThreadMap
@@ -158,10 +157,7 @@ export function createParseNodesInANewThread(mmParser: MmParser, callback: Progr
 	const mmpRulesForThread: IMmpRuleForThread[] =
 		GrammarManagerForThread.convertMmpRules(<MmpRule[]>mmParser.grammar.rules);
 
-	callback({
-		kind: 'log',
-		text: 'I am the Main thread!!!!!!!: labelToFormulaMap.size = ' + labelToFormulaMap.size
-	} satisfies MessageLog);
+	callback(createMessageLog('I am the Main thread!!!!!!!: labelToFormulaMap.size = ' + labelToFormulaMap.size));
 
 	// Create the worker.
 	const workerFileName: string = __filename.replace('src', 'out').replace('.ts', '.js');
@@ -174,7 +170,7 @@ export function createParseNodesInANewThread(mmParser: MmParser, callback: Progr
 		// Listen for messages from the worker and print them.
 		worker.on('message', (message: Message) => {
 			if (message.kind === 'done') {
-				callback({kind: 'log', text: ('I am back to the Main thread!!!!!!!')} satisfies MessageLog);
+				callback(createMessageLog('I am back to the Main thread!!!!!!!'));
 				addParseNodes(message.labelToParseNodeForThreadMap, mmParser.labelToStatementMap);
 				resolve();
 				mmParser.areAllParseNodesComplete = true;


### PR DESCRIPTION
1. Adds a newLabel MmParser event and exposes the parseFromTokenReader method.

This makes it possible to do more with the MmParser - I can find out exactly where a proof starts and ends in a .mm file, and thus can use yamma to compress and decompress proofs within a .mm file (being able to decompress proofs is very good for learning Metamath even if it isn't ultimately particularly useful).

2. Support single threaded parsing of .mm files in exactly the same way parsing with a worker threads functions.

It's a lot easier to profile a single threaded program in Chrome Dev Tools, although ultimately I didn't profile that way.  So I could live without this, but I do like the flexibility of having a --single-thread option.  I haven't tried using yamma from inside a web page, and it's not my intention to try any time soon, but this would be a useful step in that direction because the worker thread is node-specific (and not quite the same thing as a webworker which would be available in that environment).